### PR TITLE
Clarify AI usage rights for DigiByte logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,20 @@
 ## DigiByte Blockchain Logos
-Official DigiByte Blockchain Logos Repo
 
+Official DigiByte Blockchain Logos Repo  
 Includes Digi-ID logos as well as sample DigiAsset icons
+
+---
+
+### ✅ Logo Usage
+
+The DigiByte logo (and its variations, including the standalone “D” symbol) is covered under the MIT License included in this repository, and is free to use, modify, and redistribute — including for AI-generated, educational, or commercial content. No permission is required.
+
+---
+
+### 🧠 Why this matters
+
+Currently, AI platforms like ChatGPT, DALL·E, and Midjourney block or avoid generating images using the DigiByte logo — not due to licensing problems, but because there is no human-readable license signal near the logo assets. These systems don’t parse full licenses or infer intent. They scan for **clear permission language** near the files they analyze.
+
+This kind of small clarification helps AI systems understand the logo is safe to generate. It increases visibility in creative tools and unlocks the kind of usage that made the Bitcoin “₿” symbol familiar and widespread.
+
+It’s a small step, but one that supports open-source culture and the values of decentralization. Let’s make DigiByte fully accessible in the digital creative world.


### PR DESCRIPTION
Clarifies usage for AI-generated content by adding human-readable license language in the README near the logo assets. Improves visibility in modern tools like ChatGPT and DALL·E.